### PR TITLE
use protocol relative urls for active content

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -6,7 +6,7 @@
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,11 +1,11 @@
 <footer class="footer" role="contentinfo">
-  <iframe src="http://ghbtns.com/github-btn.html?user=articlemetrics&repo=alm&type=watch&count=true"
+  <iframe src="//mdo.github.io/github-buttons/github-btn.html?user=articlemetrics&repo=alm&type=watch&count=true"
   allowtransparency="true" frameborder="0" scrolling="0" width="100" height="20"></iframe>
 
-  <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=articlemetrics&repo=alm&type=fork&count=true"
+  <iframe class="github-btn" src="//mdo.github.io/github-buttons/github-btn.html?user=articlemetrics&repo=alm&type=fork&count=true"
   allowtransparency="true" frameborder="0" scrolling="0" width="100" height="20"></iframe>
 
-  <iframe src="http://ghbtns.com/github-btn.html?user=articlemetrics&type=follow&count=true"
+  <iframe src="//mdo.github.io/github-buttons/github-btn.html?user=articlemetrics&type=follow&count=true"
   allowtransparency="true" frameborder="0" scrolling="0" width="180" height="20"></iframe>
 
   <p>Maintained by the core team with the help of our <a href="/docs/Contributors">contributors</a>.<br/>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -34,11 +34,11 @@
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <!-- Fonts -->
-    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,400italic,600italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,400italic,600italic' rel='stylesheet' type='text/css'>
 
     <!-- CSS -->
     <link rel="stylesheet" href="/css/bootstrap.min.css">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,8 +34,8 @@
 
     {% include analytics.html %}
 
-    <script src="http://code.jquery.com/jquery.js"></script>
+    <script src="//code.jquery.com/jquery.js"></script>
     <script src="/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   </body>
 </html>


### PR DESCRIPTION
switch the `http://` urls to `//` protocol relative urls
http://www.paulirish.com/2010/the-protocol-relative-url/

only applies to "active content" like `<script>` and `<iframe>`
https://developer.mozilla.org/en-US/docs/Security/MixedContent

solves #2 
